### PR TITLE
eated_atカラムの廃止とlinebot整備

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -40,12 +40,11 @@ class LineBotController < ApplicationController
         when "食事の記録"
           message = {
                       type: "text",
-                      text: "メッセージで食べたもののメニュー名を送ると記録されます。" +
-                      "送った際の時刻に食べたものとして記録されます。" +
-                      "時間指定をして記録したい場合は、サイトから実行してください。"
+                      text: "食べたものの名前をメッセージしてください。\n
+                      送った時刻に食べたものとして記録されます。"
                     }
 
-        when "便の記録"
+        when "排便の記録"
           message = LineBot::Messages::UnkoMessage.new.button_message
 
         when "0", "1", "2"
@@ -117,6 +116,23 @@ class LineBotController < ApplicationController
                       text: avert_meal
                     }
 
+        when "使用説明"
+          message = {
+                      type: "text",
+                      text: "①LINE連携ログインが完了済みか確認する\n
+                      このLINEBOTはサイトでのLINE連携ログインが完了していることが前提条件です。\n
+                      まだの方はサイトにアクセスボタンからログインを実施してください。\n
+                      ②食事の記録の仕方\n
+                      食事名をメッセージで送信すると、その時刻に食べたものとして記録されます。\n
+                      ③排便の記録\n
+                      排便の記録ボタンを押すと3択の選択肢ボタンが送られてきます[0:良い, 1:普通, 2:悪い]\n
+                      自分の便の状態を3段階で判断して、該当するボタンをクリックしてください。
+                      クリックした状態と時刻で記録されます。\n
+                      ④おすすめの食事・避けるべき食事\n
+                      それぞれのボタンをクリックすると、あなたと相性の良い食事、悪い食事が送られてきます。\n
+                      まだ判定ができていない場合は、データが足りていないので、記録を継続してから再度試してください"
+                    }
+
         # 食事メニューの記録を行う
         else
           # 入力されたテキストを受け取り、mealsテーブルにそれが無ければ新規に登録する
@@ -131,7 +147,7 @@ class LineBotController < ApplicationController
           end
           # evaluationテーブルにデータを保存する。評価値であるscoreのデフォルトは0
           # saveの成否に応じてユーザーへの返信内容を設定する
-          eating = Eating.new(user_id: user_id, meal_id: meal_id, eated_at: Time.current)
+          eating = Eating.new(user_id: user_id, meal_id: meal_id)
           if eating.save
             meal_log_reply_message = "食事の記録が完了しました。"
           else

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -14,7 +14,7 @@ class MealsController < ApplicationController
       meal.save
       meal_id = meal.id
     end
-    eating = Eating.new(user_id: user_id, meal_id: meal_id, eated_at: params[:eated_at])
+    eating = Eating.new(user_id: user_id, meal_id: meal_id, created_at: params[:created_at])
     if eating.save
       flash[:notice] = '食事を記録しました'
       redirect_to user_path(current_user)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,11 +18,10 @@ class UsersController < ApplicationController
     @log_index = meal_log_index.concat(stool_log_index)
     @log_index = @log_index.sort_by do |log|
       if log.is_a?(Eating)
-        log.eated_at
+        log.created_at
       elsif log.is_a?(Stool)
         log.created_at
       end
     end
-    p @log_index
   end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -14,10 +14,10 @@
           </div>
           <div class="md:flex md:items-center mb-6">
             <div class="md:w-1/3">
-              <%= f.label :eated_at, "食べた時間", class: "block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4" %>
+              <%= f.label :created_at, "食べた時間", class: "block text-gray-500 font-bold md:text-right mb-1 md:mb-0 pr-4" %>
             </div>
             <div class="md:w-2/3">
-              <%= f.datetime_field :eated_at, value: Time.current.strftime('%Y-%m-%dT'), class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500" %>
+              <%= f.datetime_field :created_at, value: Time.current.strftime('%Y-%m-%dT'), class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500" %>
             </div>
           </div>
           <div class="md:flex md:items-center">
@@ -103,7 +103,7 @@
                   <th></th>
                   <td><%= log.meal.meal_name %></td>
                   <td>-</td> 
-                  <td><%= log.eated_at.strftime('%Y-%m-%d %H:%M') %></td>
+                  <td><%= log.created_at.strftime('%Y-%m-%d %H:%M') %></td>
                   <td><%= button_to '削除', eating_path(log.id), method: :delete %></td>
                   <th></th>
                 </tr>

--- a/db/migrate/20240501083509_remove_eated_at_from_eatings.rb
+++ b/db/migrate/20240501083509_remove_eated_at_from_eatings.rb
@@ -1,0 +1,5 @@
+class RemoveEatedAtFromEatings < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :eatings, :eated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_20_083319) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_01_083509) do
   create_table "eatings", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "meal_id"
-    t.datetime "eated_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["meal_id"], name: "index_eatings_on_meal_id"


### PR DESCRIPTION
# 概要
eated_atカラムの廃止と、linebotの整備を実施しました。

## 変更内容
- eated_atカラムを削除して、created_atカラムを使用するように各ファイルを修正
- linebotの使用説明ボタンの動作を作成
- 便の記録を排便の記録に文字列変更