### PR TITLE
入力フォームのバグ修正

### DIFF
--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -19,8 +19,8 @@ class MealsController < ApplicationController
       flash[:notice] = '食事を記録しました'
       redirect_to user_path(current_user)
     else
-      flash.now[:danger] = '食事の記録に失敗しました'
-      render("user/show")
+      flash[:alert] = '食事の記録に失敗しました'
+      redirect_to user_path(current_user)
     end
   end
 

--- a/app/controllers/stools_controller.rb
+++ b/app/controllers/stools_controller.rb
@@ -18,13 +18,13 @@ class StoolsController < ApplicationController
     end
     start_time = stool.created_at - 50.hours
     end_time = stool.created_at - 20.hours
-    eatings = Eating.where(eated_at: start_time..end_time).where(user_id: current_user.id)
+    eatings = Eating.where(created_at: start_time..end_time).where(user_id: current_user.id)
     eatings.each do |eating|
       meal = Meal.find(eating.meal_id)
       p meal
       unless meal.update(score: meal.score + score_change)
-        flash.now[:danger] = '排便の記録に失敗しました'
-        render("user/show") and return
+        flash.now[:alert] = '排便の記録に失敗しました'
+        redirect_to user_path(current_user) and return
       end
     end
     flash[:notice] = '排便を記録しました'

--- a/app/models/meal.rb
+++ b/app/models/meal.rb
@@ -1,4 +1,5 @@
 class Meal < ApplicationRecord
   belongs_to :user
   has_many :eatings, dependent: :destroy
+  validates :meal_name, presence: true, length: { maximum: 30 }
 end

--- a/app/models/stool.rb
+++ b/app/models/stool.rb
@@ -1,4 +1,5 @@
 class Stool < ApplicationRecord
   belongs_to :user
   enum condition: { good: 0, normal: 1, bad: 2 }
+  validates :condition, presence: true, length: { maximum: 30 }
 end


### PR DESCRIPTION
# 概要
動作確認中に発覚したバグを修正

# 変更内容
- 食事の記録でエラーが出た際のリダイレクトをrenderからredirectに変更
- stoolsコントローラーで使用されていたeated_atをcreated_atに修正
- meal_nameカラムとconditionカラムにバリデーションを追加