### PR TITLE
fix:フラッシュメッセージがヘッダーに埋まるバグを修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,8 +25,10 @@
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>
-    <%= render 'shared/flash_message' %>
-    <%= yield %>
+    <div class="pt-16">
+      <%= render 'shared/flash_message' %>
+      <%= yield %>
+    </div>
     <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -1,4 +1,4 @@
-<div class="pt-16">
+<div>
   <div class="hero min-h-fit bg-base-200">
     <div class="hero-content text-center">
       <div class="max-w-xl">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-base-200 space-y-10 pt-16">
+<div class="bg-base-200 space-y-10">
   <div class="md:flex justify-center items-center gap-4 space-y-4 mx-auto max-w-screen-md">
     <div class="card w-96 bg-base-100 shadow-xl mx-auto">
       <div class="card-body">


### PR DESCRIPTION
- フラッシュメッセージがヘッダーに埋まっていたので、修正しました。
- users/show.html.erbとstatic_pages/index.html.erbのpt-16を削除
- layouts/application.html.erbで、フラッシュメッセージパーシャルとyieldをまとめて<div class="pt-16">で囲む