### PR TITLE
fix:排便記録を空白で記録した時に普通で記録されるように修正

### DIFF
--- a/app/controllers/stools_controller.rb
+++ b/app/controllers/stools_controller.rb
@@ -1,7 +1,12 @@
 class StoolsController < ApplicationController
 
   def create
-    stool = Stool.new(condition: params[:condition].to_i, user_id: current_user.id, created_at:params[:created_at])
+    if params[:condition] == ""
+      condition = 1
+    else
+      condition = params[:condition].to_i
+    end
+    stool = Stool.new(condition: condition, user_id: current_user.id, created_at:params[:created_at])
     unless stool.save
       flash.now[:danger] = '排便の記録に失敗しました'
       render("user/show")

--- a/db/migrate/20240511044129_change_condition_default_on_stools.rb
+++ b/db/migrate/20240511044129_change_condition_default_on_stools.rb
@@ -1,0 +1,5 @@
+class ChangeConditionDefaultOnStools < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :stools, :condition, from: 0, to: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_01_083509) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_11_044129) do
   create_table "eatings", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "meal_id"
@@ -31,7 +31,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_01_083509) do
 
   create_table "stools", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.integer "condition", default: 0, null: false
+    t.integer "condition", default: 1, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_stools_on_user_id"


### PR DESCRIPTION
### 変更前
- マイページの排便記録フォームを空白で送ると、0:良いの状態で記録されていた。
### 変更後
- 空白で送ると、1:普通の状態で記録されるようになった。