### PR TITLE
add:記録回数、スコア、食事名一覧を実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,15 +2,18 @@ class UsersController < ApplicationController
   before_action :authenticate_user!
 
   def show
+    # おすすめの食事用のインスタンス変数
     @recommend_meals = current_user.meals.where('score >= ?', 3)
     if @recommend_meals.nil?
       @recommend_meals = current_user.meals.where('score >= ?', 1)
     end
+    # 避けるべき食事用のインスタンス変数
     @avert_meals = current_user.meals.where('score <= ?', -3)
     if @avert_meals.nil?
       @avert_meals = current_user.meals.where('score >= ?', 1)
     end
 
+    # 記録履歴一覧用のインスタンス変数
     meal_log_index = current_user.eatings.includes(:meal)
     stool_log_index = current_user.stools
     meal_log_index = meal_log_index.to_a
@@ -23,5 +26,20 @@ class UsersController < ApplicationController
         log.created_at
       end
     end
+
+    # 通算記録回数表示用のインスタンス変数
+    @eating_count = current_user.eatings.count
+    @stool_count = current_user.stools.count
+    @log_count = @eating_count + @stool_count
+    # 今月の記録回数表示用のインスタンス変数
+    @this_month_eating_count = current_user.eatings.where(created_at: Time.current.beginning_of_month..Time.current.end_of_month).count
+    @this_month_stool_count = current_user.stools.where(created_at: Time.current.beginning_of_month..Time.current.end_of_month).count
+    # 先月の記録回数表示用のインスタンス変数
+    @last_month_eating_count = current_user.eatings.where(created_at: Time.current.last_month.beginning_of_month..Time.current.last_month.end_of_month).count
+    @last_month_stool_count = current_user.stools.where(created_at: Time.current.last_month.beginning_of_month..Time.current.last_month.end_of_month).count
+
+    # 登録済みの食事メニュー一覧用のインスタンス変数
+    @my_meal_count = current_user.eatings.group(:meal_id).count
+    @meals = current_user.meals
   end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -126,7 +126,7 @@
                   <% end %>
                   <td><%= log.created_at.strftime('%Y-%m-%d %H:%M') %></td>
                   <% unless current_user.id == 2 %>
-                    <td><%= button_to '削除', stool_path(log.id), method: :delete, form: { data: { turbo_confirm: "削除しますか？" } } %></td>
+                    <td><%= button_to '削除', stool_path(log.id), method: :delete %></td>
                   <% end %>
                   <th></th>
                 </tr>
@@ -134,6 +134,62 @@
             <% end %>
           <% end %>
         </table>
+      </div>
+    </div>
+  </div>
+  <div class="md:flex justify-center items-center gap-4 space-y-4 mx-auto max-w-screen-md">
+    <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
+      <div class="card-body">
+        <h2 class="card-title">記録回数の実績</h2>
+        <div class="max-h-72 overflow-auto">
+          <h3><strong>通算</strong></h3>
+            <p>食事：<%= @eating_count %> 回</p>
+            <p>排便：<%= @stool_count %> 回</p>
+          <h3><strong>今月</strong></h3>
+            <p>食事：<%= @this_month_eating_count %> 回</p>
+            <p>排便：<%= @this_month_stool_count %> 回</p>
+          <h3><strong>先月</strong></h3>
+            <p>食事：<%= @last_month_eating_count %> 回</p>
+            <p>排便：<%= @last_month_stool_count %> 回</p>
+        </div>
+      </div>
+    </div>
+    <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
+      <div class="card-body">
+        <h2 class="card-title">登録済みの食事名一覧</h2>
+        <div class="max-h-72 overflow-auto">
+          <table class="table table-xs table-pin-rows table-pin-cols">
+            <thead>
+              <tr>
+                <th></th> 
+                <td>食事名</td> 
+                <td>記録回数</td> 
+                <th></th> 
+              </tr>
+            </thead> 
+            <% @meals.each do |meal| %>
+              <% meal_id = meal.id %>
+              <tbody>
+                <tr>
+                  <th></th>
+                  <td><%= meal.meal_name %></td>
+                  <td><%= @my_meal_count[meal_id] %></td>
+                  <th></th>
+                </tr>
+              </tbody>
+            <% end %>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="md:flex justify-center items-center gap-4 space-y-4 mx-auto max-w-screen-md">
+    <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
+      <div class="card-body">
+        <h2 class="card-title">マイスコア</h2>
+        <div class="flex items-center justify-center text-9xl">
+          <%= @log_count %>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# 概要
マイページの記録統計機能の実装です。
issueの3分の1ほどの完了分のプルリクです。

## 変更内容
- マイページに記録回数表示のカードを追加
- マイページにスコアカードを追加
- マイページに登録済みの食事一覧カードを追加