### PR TITLE
食事記録時に他ユーザーと重複して管理されてしまうバグ修正

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -40,8 +40,7 @@ class LineBotController < ApplicationController
         when "食事の記録"
           message = {
                       type: "text",
-                      text: "食べたものの名前をメッセージしてください。\n
-                      送った時刻に食べたものとして記録されます。"
+                      text: "食べたものの名前をメッセージしてください。\n送った時刻に食べたものとして記録されます。"
                     }
 
         when "排便の記録"
@@ -137,7 +136,7 @@ class LineBotController < ApplicationController
         else
           # 入力されたテキストを受け取り、mealsテーブルにそれが無ければ新規に登録する
           meal_log = event.message["text"]
-          meal = Meal.find_by(meal_name: meal_log)
+          meal = Meal.find_by(meal_name: meal_log, user_id: user_id)
           if meal.present?
             meal_id = meal.id
           else

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -6,7 +6,7 @@ class MealsController < ApplicationController
 
   def create
     user_id = current_user.id
-    meal = Meal.find_by(meal_name: params[:meal_name])
+    meal = Meal.find_by(meal_name: params[:meal_name], user_id: user_id)
     if meal.present?
       meal_id = meal.id
     else


### PR DESCRIPTION
# 概要
食事の記録をした際に、すでに登録した食事であれば、既存のデータを使用する設定をしていた。
この設定部分に問題があり、他のユーザーがすでに登録している食事名と重複した際に、
その食事データを使うようになってしまい、評価値が他ユーザーと共有になってしまっていた。
その該当箇所を修正した。

## 変更内容
- meals_controllerのcreateアクションを修正
- line_bot_controllerの食事記録部分を修正