### PR TITLE
add:マイページに統計などの確認機能を実装

### DIFF
--- a/app/controllers/stools_controller.rb
+++ b/app/controllers/stools_controller.rb
@@ -12,9 +12,9 @@ class StoolsController < ApplicationController
       render("user/show")
       return
     end
-    if params[:condition].to_i == 0
+    if condition == 0
       score_change = 1
-    elsif params[:condition].to_i == 2
+    elsif condition == 2
       score_change = -1
     else
       flash[:notice] = '排便を記録しました'
@@ -24,6 +24,7 @@ class StoolsController < ApplicationController
     start_time = stool.created_at - 50.hours
     end_time = stool.created_at - 20.hours
     eatings = Eating.where(created_at: start_time..end_time).where(user_id: current_user.id)
+    p score_change
     eatings.each do |eating|
       meal = Meal.find(eating.meal_id)
       unless meal.update(score: meal.score + score_change)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -41,5 +41,32 @@ class UsersController < ApplicationController
     # 登録済みの食事メニュー一覧用のインスタンス変数
     @my_meal_count = current_user.eatings.group(:meal_id).count
     @meals = current_user.meals
+
+    # 通算の胃腸の状況用のインスタンス変数
+    @stool_good_count = current_user.stools.where(condition: "good").count
+    @stool_normal_count = current_user.stools.where(condition: "normal").count
+    @stool_bad_count = current_user.stools.where(condition: "bad").count
+    # 今月の胃腸の状況用のインスタンス変数
+    @this_month_stool_good_count = current_user.stools.where(condition: "good").where(created_at: Time.current.beginning_of_month..Time.current.end_of_month).count
+    @this_month_stool_normal_count = current_user.stools.where(condition: "normal").where(created_at: Time.current.beginning_of_month..Time.current.end_of_month).count
+    @this_month_stool_bad_count = current_user.stools.where(condition: "bad").where(created_at: Time.current.beginning_of_month..Time.current.end_of_month).count
+    # 先月の胃腸の状況用のインスタンス変数
+    @last_month_stool_good_count = current_user.stools.where(condition: "good").where(created_at: Time.current.last_month.beginning_of_month..Time.current.last_month.end_of_month).count
+    @last_month_stool_normal_count = current_user.stools.where(condition: "normal").where(created_at: Time.current.last_month.beginning_of_month..Time.current.last_month.end_of_month).count
+    @last_month_stool_bad_count = current_user.stools.where(condition: "bad").where(created_at: Time.current.last_month.beginning_of_month..Time.current.last_month.end_of_month).count
+
+    # 連続記録日数のインスタンス変数
+    @meal_log_days_record = 0
+    @stool_log_days_record = 0
+    meal_date = Date.today
+    stool_date= Date.today
+    while current_user.eatings.where("DATE(created_at) = ?", meal_date).exists?
+      @meal_log_days_record += 1
+      meal_date = meal_date.prev_day
+    end
+    while current_user.stools.where("DATE(created_at) = ?", stool_date).exists?
+      @stool_log_days_record += 1
+      stool_date = stool_date.prev_day
+    end
   end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -62,6 +62,32 @@
   <div class="md:flex justify-center items-center gap-4 space-y-4 mx-auto max-w-screen-md">
     <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
       <div class="card-body">
+        <h2 class="card-title">マイスコア</h2>
+        <div class="flex items-center justify-center text-9xl">
+          <%= @log_count %>
+        </div>
+        <div class="text-right text-xl">ポイント</div>
+      </div>
+    </div>
+    <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
+      <div class="card-body">
+        <h2 class="card-title">連続記録日数</h2>
+        <h3><strong>食事の連続記録日数</strong></h3>
+        <div class="flex items-center justify-center text-7xl">
+          <%= @meal_log_days_record %>
+        </div>
+        <div class="text-right text-3xl">日</div>
+        <h3><strong>排便の連続記録日数</strong></h3>
+        <div class="flex items-center justify-center text-7xl">
+          <%= @stool_log_days_record %>
+        </div>
+        <div class="text-right text-3xl">日</div>
+      </div>
+    </div>
+  </div>
+  <div class="md:flex justify-center items-center gap-4 space-y-4 mx-auto max-w-screen-md">
+    <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
+      <div class="card-body">
         <h2 class="card-title">おすすめの食事</h2>
         <div class="max-h-72 overflow-auto">
           <% @recommend_meals.each do |recommend_meal| %>
@@ -78,62 +104,6 @@
             <p><%= avert_meal.meal_name %></p>
           <% end %>
         </div>
-      </div>
-    </div>
-  </div>
-  <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
-    <div class="card-body">
-      <h2 class="card-title">記録履歴一覧</h2>
-      <div class="max-h-72 overflow-auto">
-        <table class="table table-xs table-pin-rows table-pin-cols">
-          <thead>
-            <tr>
-              <th></th> 
-              <td>食事名</td> 
-              <td>便の状態</td> 
-              <td>記録日時</td> 
-              <td>削除ボタン</td> 
-              <th></th> 
-            </tr>
-          </thead> 
-          <% @log_index.each do |log| %>
-            <% if log.is_a?(Eating) %>
-              <tbody>
-                <tr>
-                  <th></th>
-                  <td><%= log.meal.meal_name %></td>
-                  <td>-</td> 
-                  <td><%= log.created_at.strftime('%Y-%m-%d %H:%M') %></td>
-                  <% unless current_user.id == 2 %>
-                    <td><%= button_to '削除', eating_path(log.id), method: :delete %></td>
-                  <% end %>
-                  <th></th>
-                </tr>
-              </tbody> 
-            <% elsif log.is_a?(Stool) %>
-              <tbody>
-                <tr>
-                  <th></th>
-                  <td>-</td> 
-                  <% if log.condition == "good" %>
-                    <td>良い</td>
-                  <% elsif log.condition == "normal" %>
-                    <td>普通</td>
-                  <% elsif log.condition == "bad" %>
-                    <td>悪い</td>
-                  <% else %>
-                    <td><%= log.condition %></td>
-                  <% end %>
-                  <td><%= log.created_at.strftime('%Y-%m-%d %H:%M') %></td>
-                  <% unless current_user.id == 2 %>
-                    <td><%= button_to '削除', stool_path(log.id), method: :delete %></td>
-                  <% end %>
-                  <th></th>
-                </tr>
-              </tbody> 
-            <% end %>
-          <% end %>
-        </table>
       </div>
     </div>
   </div>
@@ -182,13 +152,78 @@
         </div>
       </div>
     </div>
-  </div>
-  <div class="md:flex justify-center items-center gap-4 space-y-4 mx-auto max-w-screen-md">
     <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
       <div class="card-body">
-        <h2 class="card-title">マイスコア</h2>
-        <div class="flex items-center justify-center text-9xl">
-          <%= @log_count %>
+        <h2 class="card-title">胃腸の状況</h2>
+        <div class="max-h-72 overflow-auto">
+          <h3><strong>便の状態ごとの記録回数(通算)</strong></h3>
+            <p>良い：<%= @stool_good_count %> 回</p>
+            <p>普通：<%= @stool_normal_count %> 回</p>
+            <p>悪い：<%= @stool_bad_count %> 回</p>
+          <h3><strong>便の状態ごとの記録回数(今月)</strong></h3>
+            <p>良い：<%= @this_month_stool_good_count %> 回</p>
+            <p>普通：<%= @this_month_stool_normal_count %> 回</p>
+            <p>悪い：<%= @this_month_stool_bad_count %> 回</p>
+          <h3><strong>便の状態ごとの記録回数(先月)</strong></h3>
+            <p>良い：<%= @last_month_stool_good_count %> 回</p>
+            <p>普通：<%= @last_month_stool_normal_count %> 回</p>
+            <p>悪い：<%= @last_month_stool_bad_count %> 回</p>
+        </div>
+      </div>
+    </div>
+    <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
+      <div class="card-body">
+        <h2 class="card-title">記録履歴一覧</h2>
+        <div class="max-h-72 overflow-auto">
+          <table class="table table-xs table-pin-rows table-pin-cols">
+            <thead>
+              <tr>
+                <th></th> 
+                <td>食事名</td> 
+                <td>便の状態</td> 
+                <td>記録日時</td> 
+                <td>削除ボタン</td> 
+                <th></th> 
+              </tr>
+            </thead> 
+            <% @log_index.each do |log| %>
+              <% if log.is_a?(Eating) %>
+                <tbody>
+                  <tr>
+                    <th></th>
+                    <td><%= log.meal.meal_name %></td>
+                    <td>-</td> 
+                    <td><%= log.created_at.strftime('%Y-%m-%d %H:%M') %></td>
+                    <% unless current_user.id == 2 %>
+                      <td><%= button_to '削除', eating_path(log.id), method: :delete %></td>
+                    <% end %>
+                    <th></th>
+                  </tr>
+                </tbody> 
+              <% elsif log.is_a?(Stool) %>
+                <tbody>
+                  <tr>
+                    <th></th>
+                    <td>-</td> 
+                    <% if log.condition == "good" %>
+                      <td>良い</td>
+                    <% elsif log.condition == "normal" %>
+                      <td>普通</td>
+                    <% elsif log.condition == "bad" %>
+                      <td>悪い</td>
+                    <% else %>
+                      <td><%= log.condition %></td>
+                    <% end %>
+                    <td><%= log.created_at.strftime('%Y-%m-%d %H:%M') %></td>
+                    <% unless current_user.id == 2 %>
+                      <td><%= button_to '削除', stool_path(log.id), method: :delete %></td>
+                    <% end %>
+                    <th></th>
+                  </tr>
+                </tbody> 
+              <% end %>
+            <% end %>
+          </table>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# 概要
マイページに、自分の記録履歴やスコアを確認できる機能を追加しました。
また、作業の過程で判明したバグの修正も行なっています。

## 追加機能
- 登録済みの食事メニューを記録かされた回数と共に一覧表示
- 排便状態ごとの記録回数表示
- 連続で記録を継続できている日数を表示
- 通算、今月、先月の食事と排便の記録回数表示
- マイページの要素の並び順を変更

## バグ修正
- 排便記録時に入力欄を空白で記録ボタンを押した際の挙動を修正