### PR TITLE
add:記録履歴一覧に並び替えボタンを追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,12 +19,10 @@ class UsersController < ApplicationController
     meal_log_index = meal_log_index.to_a
     stool_log_index = stool_log_index.to_a
     @log_index = meal_log_index.concat(stool_log_index)
-    @log_index = @log_index.sort_by do |log|
-      if log.is_a?(Eating)
-        log.created_at
-      elsif log.is_a?(Stool)
-        log.created_at
-      end
+    if params[:desc]
+      @log_index = @log_index.sort_by { |log| log.created_at }.reverse
+    else
+      @log_index = @log_index.sort_by { |log| log.created_at }
     end
 
     # 通算記録回数表示用のインスタンス変数

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-base-200 space-y-10">
+<div class="bg-base-200 space-y-10 pt-4 pb-4">
   <div class="md:flex justify-center items-center gap-4 space-y-4 mx-auto max-w-screen-md">
     <div class="card w-96 bg-base-100 shadow-xl mx-auto">
       <div class="card-body">
@@ -176,7 +176,11 @@
     <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
       <div class="card-body">
         <h2 class="card-title">記録履歴一覧</h2>
-        <div class="max-h-72 overflow-auto">
+        <div class="flex">
+          <%= link_to '古い順', user_path(current_user), class: "bg-base-300 hover:bg-base-200 font-bold py-2 px-4 rounded-full w-20" %>
+          <%= link_to '新しい順', user_path(current_user, desc: "true"), class: "bg-base-300 hover:bg-base-200 font-bold py-2 px-4 rounded-full w-24" %>
+        </div>
+        <div class="max-h-64 overflow-auto">
           <table class="table table-xs table-pin-rows table-pin-cols">
             <thead>
               <tr>


### PR DESCRIPTION
- マイページの記録履歴一覧に並び替えボタンを追加した。
- 古い順ボタンを押すと日付が古い順に並ぶ。
- 新しい順ボタンを押すと日付が新しい順に並ぶ。