### PR TITLE
add:マイページのボタンを非同期処理化した

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,22 +10,17 @@ class ApplicationController < ActionController::Base
     if params[:desc]
       @log_index = @log_index.sort_by { |log| log.created_at }.reverse
       session[:sort] = "desc"
-      p "params descで判定"
     elsif params[:asc]
       @log_index = @log_index.sort_by { |log| log.created_at }
       session[:sort] = "asc"
-      p "params ascで判定"
     else
       if session[:sort] == "desc"
         @log_index = @log_index.sort_by { |log| log.created_at }.reverse
         session[:sort] = "desc"
-        p "session descで判定"
       elsif session[:sort] == "asc"
         @log_index = @log_index.sort_by { |log| log.created_at }
         session[:sort] = "asc"
-        p "session descで判定"
       end
     end
-    p session[:sort]
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,31 @@
 class ApplicationController < ActionController::Base
   skip_before_action :verify_authenticity_token
+
+  private
+
+  def set_log_index
+    meal_log_index = current_user.eatings.includes(:meal).to_a
+    stool_log_index = current_user.stools.to_a
+    @log_index = meal_log_index.concat(stool_log_index)
+    if params[:desc]
+      @log_index = @log_index.sort_by { |log| log.created_at }.reverse
+      session[:sort] = "desc"
+      p "params descで判定"
+    elsif params[:asc]
+      @log_index = @log_index.sort_by { |log| log.created_at }
+      session[:sort] = "asc"
+      p "params ascで判定"
+    else
+      if session[:sort] == "desc"
+        @log_index = @log_index.sort_by { |log| log.created_at }.reverse
+        session[:sort] = "desc"
+        p "session descで判定"
+      elsif session[:sort] == "asc"
+        @log_index = @log_index.sort_by { |log| log.created_at }
+        session[:sort] = "asc"
+        p "session descで判定"
+      end
+    end
+    p session[:sort]
+  end
 end

--- a/app/controllers/eatings_controller.rb
+++ b/app/controllers/eatings_controller.rb
@@ -2,6 +2,6 @@ class EatingsController < ApplicationController
   def destroy
     eating = Eating.find(params[:id])
     eating.destroy!
-    redirect_to user_url(current_user), status: :see_other
+    set_log_index
   end
 end

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -1,9 +1,5 @@
 class MealsController < ApplicationController
 
-  # def index; end
-
-  # def new; end
-
   def create
     user_id = current_user.id
     if params[:meal_name].present?
@@ -29,13 +25,6 @@ class MealsController < ApplicationController
     end
   end
 
-  # def show; end
-
-  # def edit; end
-
-  # def update; end
-
   def destroy 
-    
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -11,9 +11,6 @@ class StaticPagesController < ApplicationController
     else
       session[:number] = @number
     end
-    respond_to do |format|
-      format.turbo_stream
-    end
   end
 
   def decrement
@@ -23,9 +20,6 @@ class StaticPagesController < ApplicationController
       session[:number] = @number
     else
       session[:number] = @number
-    end
-    respond_to do |format|
-      format.turbo_stream
     end
   end
 end

--- a/app/controllers/stools_controller.rb
+++ b/app/controllers/stools_controller.rb
@@ -56,6 +56,6 @@ class StoolsController < ApplicationController
       end
     end
     stool.destroy!
-    redirect_to user_url(current_user), status: :see_other
+    set_log_index
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,16 +14,7 @@ class UsersController < ApplicationController
     end
 
     # 記録履歴一覧用のインスタンス変数
-    meal_log_index = current_user.eatings.includes(:meal)
-    stool_log_index = current_user.stools
-    meal_log_index = meal_log_index.to_a
-    stool_log_index = stool_log_index.to_a
-    @log_index = meal_log_index.concat(stool_log_index)
-    if params[:desc]
-      @log_index = @log_index.sort_by { |log| log.created_at }.reverse
-    else
-      @log_index = @log_index.sort_by { |log| log.created_at }
-    end
+    set_log_index
 
     # 通算記録回数表示用のインスタンス変数
     @eating_count = current_user.eatings.count
@@ -68,10 +59,15 @@ class UsersController < ApplicationController
     end
   end
 
+  # 食事記録フォームの入力補助
   def search
     @suggest_meals = Meal.where("meal_name like ?", "%#{params[:q]}%")
     respond_to do |format|
       format.js
     end
-  end  
+  end
+
+  def sort
+    set_log_index
+  end
 end

--- a/app/views/eatings/destroy.turbo_stream.erb
+++ b/app/views/eatings/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "log_index_frame" do %>
+  <%= render 'shared/log_index' %>
+<% end %>

--- a/app/views/shared/_log_index.html.erb
+++ b/app/views/shared/_log_index.html.erb
@@ -1,0 +1,60 @@
+<div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
+  <div class="card-body">
+    <h2 class="card-title">記録履歴一覧</h2>
+    <div class="flex">
+      <%= link_to '古い順', sort_log_users_path(asc: "true"), data: { turbo_method: :post, turbo_frame: "log_index_frame" }, class: "bg-base-300 hover:bg-base-200 font-bold py-2 px-4 rounded-full w-20" %>
+      <%= link_to '新しい順', sort_log_users_path(desc: "true"), data: { turbo_method: :post, turbo_frame: "log_index_frame" }, class: "bg-base-300 hover:bg-base-200 font-bold py-2 px-4 rounded-full w-24" %>
+    </div>
+    <div class="max-h-64 overflow-auto">
+      <table class="table table-xs table-pin-rows table-pin-cols">
+        <thead>
+          <tr>
+            <th></th> 
+            <td>食事名</td> 
+            <td>便の状態</td> 
+            <td>記録日時</td> 
+            <td>削除ボタン</td> 
+            <th></th> 
+          </tr>
+        </thead>
+        <% @log_index.each do |log| %>
+          <% if log.is_a?(Eating) %>
+            <tbody>
+              <tr>
+                <th></th>
+                <td><%= log.meal.meal_name %></td>
+                <td>-</td> 
+                <td><%= log.created_at.strftime('%Y-%m-%d %H:%M') %></td>
+                <% unless current_user.id == 2 %>
+                  <td><%= link_to '削除', eating_path(log.id), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } %></td>
+                <% end %>
+                <th></th>
+              </tr>
+            </tbody> 
+          <% elsif log.is_a?(Stool) %>
+            <tbody>
+              <tr>
+                <th></th>
+                <td>-</td> 
+                <% if log.condition == "good" %>
+                  <td>良い</td>
+                <% elsif log.condition == "normal" %>
+                  <td>普通</td>
+                <% elsif log.condition == "bad" %>
+                  <td>悪い</td>
+                <% else %>
+                  <td><%= log.condition %></td>
+                <% end %>
+                <td><%= log.created_at.strftime('%Y-%m-%d %H:%M') %></td>
+                <% unless current_user.id == 2 %>
+                  <td><%= link_to '削除', stool_path(log.id), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } %></td>
+                <% end %>
+                <th></th>
+              </tr>
+            </tbody> 
+          <% end %>
+        <% end %>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/stools/destroy.turbo_stream.erb
+++ b/app/views/stools/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "log_index_frame" do %>
+  <%= render 'shared/log_index' %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,7 +25,7 @@
           <div class="md:flex md:items-center">
             <div class="md:w-1/3"></div>
             <div class="md:w-2/3">
-              <%= f.submit "記録する", class: "btn btn-ghost shadow bg-base-300 hover:bg-base-400 focus:shadow-outline focus:outline-none font-bold py-2 px-4 rounded" %>
+              <%= f.submit "記録する", data: { turbo_frame: "meal_form_frame" }, class: "btn btn-ghost shadow bg-base-300 hover:bg-base-400 focus:shadow-outline focus:outline-none font-bold py-2 px-4 rounded" %>
             </div>
           </div>
         <% end %>
@@ -175,65 +175,8 @@
         </div>
       </div>
     </div>
-    <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
-      <div class="card-body">
-        <h2 class="card-title">記録履歴一覧</h2>
-        <div class="flex">
-          <%= link_to '古い順', user_path(current_user), class: "bg-base-300 hover:bg-base-200 font-bold py-2 px-4 rounded-full w-20" %>
-          <%= link_to '新しい順', user_path(current_user, desc: "true"), class: "bg-base-300 hover:bg-base-200 font-bold py-2 px-4 rounded-full w-24" %>
-        </div>
-        <div class="max-h-64 overflow-auto">
-          <table class="table table-xs table-pin-rows table-pin-cols">
-            <thead>
-              <tr>
-                <th></th> 
-                <td>食事名</td> 
-                <td>便の状態</td> 
-                <td>記録日時</td> 
-                <td>削除ボタン</td> 
-                <th></th> 
-              </tr>
-            </thead> 
-            <% @log_index.each do |log| %>
-              <% if log.is_a?(Eating) %>
-                <tbody>
-                  <tr>
-                    <th></th>
-                    <td><%= log.meal.meal_name %></td>
-                    <td>-</td> 
-                    <td><%= log.created_at.strftime('%Y-%m-%d %H:%M') %></td>
-                    <% unless current_user.id == 2 %>
-                      <td><%= link_to '削除', eating_path(log.id), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } %></td>
-                    <% end %>
-                    <th></th>
-                  </tr>
-                </tbody> 
-              <% elsif log.is_a?(Stool) %>
-                <tbody>
-                  <tr>
-                    <th></th>
-                    <td>-</td> 
-                    <% if log.condition == "good" %>
-                      <td>良い</td>
-                    <% elsif log.condition == "normal" %>
-                      <td>普通</td>
-                    <% elsif log.condition == "bad" %>
-                      <td>悪い</td>
-                    <% else %>
-                      <td><%= log.condition %></td>
-                    <% end %>
-                    <td><%= log.created_at.strftime('%Y-%m-%d %H:%M') %></td>
-                    <% unless current_user.id == 2 %>
-                      <td><%= link_to '削除', stool_path(log.id), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } %></td>
-                    <% end %>
-                    <th></th>
-                  </tr>
-                </tbody> 
-              <% end %>
-            <% end %>
-          </table>
-        </div>
-      </div>
-    </div>
+    <%= turbo_frame_tag "log_index_frame" do %>
+      <%= render 'shared/log_index' %>
+    <% end %>
   </div>
 </div>

--- a/app/views/users/sort.turbo_stream.erb
+++ b/app/views/users/sort.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "log_index_frame" do %>
+  <%= render 'shared/log_index' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   resources :users, only: %i[show] do
     collection do
       get :search
+      post :sort, as: 'sort_log'
     end
   end
   resources :meals, only: %i[create]


### PR DESCRIPTION
# 概要
マイページのユーザビリティ向上を狙って、非同期処理を実装した。

## 変更内容
- 記録履歴一覧の並び替えボタンにturbo_streamを実装
- 記録履歴一覧の削除ボタンにturbo_streamを実装
- 記録履歴一覧を格納する@log_indexの定義をプライベートメソッドset_log_indexにしてapplicationコントローラーに設置
- set_log_index内でsessionに値を保存することで、画面遷移前の並び順を保持する機能を実装
- 食事と排便の記録フォームに関しては、動作した際にマイページ上のほとんどの要素に影響を与えること、画面の上部に設置していることから非同期処理化は実施しない。

## 動作イメージ
[![Image from Gyazo](https://i.gyazo.com/6c697f3b44cd5ac5e660ac61fd412129.gif)](https://gyazo.com/6c697f3b44cd5ac5e660ac61fd412129)