### PR TITLE
fix:記録してないユーザーへの通知機能を修復

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN curl -sL https://deb.nodesource.com/setup_20.x | bash - \
   && wget --quiet -O - /tmp/pubkey.gpg https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
   && apt-get update -qq \
-  && apt-get install -y nodejs yarn
+  && apt-get install -y nodejs yarn \
+  && apt install -y cron nano
 
 WORKDIR /test_app
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -10,7 +10,9 @@ set :environment, rails_env
 # cronのログの吐き出し場所
 set :output, "#{Rails.root}/log/cron.log"
 
+ENV.each { |k, v| env(k, v) }
+
 #定期実行したい処理を記入　rakeタスクで設定したタスクを6時間ごとに実行
 every 6.hours do
-	rake 'article_publish:past_article_publish'
+  rake "log_notice:not_log_user_notice"
 end

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-
 set -e
-
 rm -f /test_app/tmp/pids/server.pid
-
+bundle exec whenever --update-crontab
+service cron start
+./bin/dev
 exec "$@"

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,0 +1,6 @@
+namespace :test do
+  desc "wheneverの動作確認用のタスク"
+  task testing: :environment do
+    p "テスト成功"
+  end
+end


### PR DESCRIPTION
# 概要
24時間記録をしていないユーザーへ通知を送る機能が動作していなかったので、修正した

## 対応した問題箇所
- docker環境にcronがインストールされていなかった。
- schedule.rbで指定していたrakeタスクの名称がコピペ元のままになっていた。
- entrypoint.shでcrontabを操作していなかった。
- cronに環境変数を引き渡していなかった。