### PR TITLE
rspec:排便記録フォームの動作確認テスト

### DIFF
--- a/app/controllers/stools_controller.rb
+++ b/app/controllers/stools_controller.rb
@@ -24,7 +24,6 @@ class StoolsController < ApplicationController
     start_time = stool.created_at - 50.hours
     end_time = stool.created_at - 20.hours
     eatings = Eating.where(created_at: start_time..end_time).where(user_id: current_user.id)
-    p score_change
     eatings.each do |eating|
       meal = Meal.find(eating.meal_id)
       unless meal.update(score: meal.score + score_change)

--- a/spec/system/stool_logs_spec.rb
+++ b/spec/system/stool_logs_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+RSpec.describe "StoolLogs", type: :system do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+    # マイページに遷移
+    visit user_path(user)
+  end
+
+  it '状態「良い」で排便を記録した時の動作を確認する' do
+    # 変動元の食事記録を作成
+    fill_in 'new_meal_name', with: 'Sample Meal'
+    fill_in 'meal_created_at', with: '002024-04-01T12:00'
+    find('.meal-btn').click
+    meal = Meal.find_by(meal_name: 'Sample Meal')
+
+    # 変動対象の食事のscoreを0に初期化
+    meal.update(score: 0)
+
+    # 排便の状態を選択
+    select '0.良い', from: 'condition'
+
+    # 排便の日時を選択
+    fill_in 'created_at', with: '002024-04-02T12:00'
+    
+    # 初期のstoolsテーブルのカウントを保存
+    initial_stool_count = Stool.count
+
+    # 記録ボタンを押す
+    find('.stool-btn').click
+
+    # stoolsテーブルのデータが増えていることを確認
+    expect(Stool.count).to eq(initial_stool_count + 1)
+
+    # mealsテーブルの特定のデータのscoreカラムの値が増えていることを確認
+    meal.reload
+    expect(meal.score).to be > 0
+
+    # フラッシュメッセージの確認
+    expect(page).to have_content '排便を記録しました'
+
+    # 遷移先画面のpathを確認
+    expect(current_path).to eq(user_path(user))
+  end
+
+  it '状態「普通」で排便を記録した時の動作を確認する' do
+    # 変動元の食事記録を作成
+    fill_in 'new_meal_name', with: 'Sample Meal'
+    fill_in 'meal_created_at', with: '002024-04-01T12:00'
+    find('.meal-btn').click
+    meal = Meal.find_by(meal_name: 'Sample Meal')
+
+    # 変動対象の食事のscoreを0に初期化
+    meal.update(score: 0)
+
+    # 排便の状態を選択
+    select '1.普通', from: 'condition'
+
+    # 排便の日時を選択
+    fill_in 'created_at', with: '002024-04-02T12:00'
+    
+    # 初期のstoolsテーブルのカウントを保存
+    initial_stool_count = Stool.count
+
+    # 記録ボタンを押す
+    find('.stool-btn').click
+
+    # stoolsテーブルのデータが増えていることを確認
+    expect(Stool.count).to eq(initial_stool_count + 1)
+
+    # mealsテーブルの特定のデータのscoreカラムの値が増えていないことを確認
+    meal.reload
+    expect(meal.score).to eq(0)
+
+    # フラッシュメッセージの確認
+    expect(page).to have_content '排便を記録しました'
+
+    # 遷移先画面のpathを確認
+    expect(current_path).to eq(user_path(user))
+  end
+
+  it '状態「悪い」で排便を記録した時の動作を確認する' do
+    # 変動元の食事記録を作成
+    fill_in 'new_meal_name', with: 'Sample Meal'
+    fill_in 'meal_created_at', with: '002024-04-01T12:00'
+    find('.meal-btn').click
+    meal = Meal.find_by(meal_name: 'Sample Meal')
+
+    # 変動対象の食事のscoreを0に初期化
+    meal.update(score: 0)
+
+    # 排便の状態を選択
+    select '2.悪い', from: 'condition'
+
+    # 排便の日時を選択
+    fill_in 'created_at', with: '002024-04-02T12:00'
+    
+    # 初期のstoolsテーブルのカウントを保存
+    initial_stool_count = Stool.count
+
+    # 記録ボタンを押す
+    find('.stool-btn').click
+
+    # stoolsテーブルのデータが増えていることを確認
+    expect(Stool.count).to eq(initial_stool_count + 1)
+
+    # mealsテーブルの特定のデータのscoreカラムの値が増えていることを確認
+    meal.reload
+    expect(meal.score).to be < 0
+
+    # フラッシュメッセージの確認
+    expect(page).to have_content '排便を記録しました'
+
+    # 遷移先画面のpathを確認
+    expect(current_path).to eq(user_path(user))
+  end
+end


### PR DESCRIPTION
# 概要
排便記録フォームの動作を確認するテストコードを追加した

## 変更内容
- stool_logs_spec.rbに排便記録フォームの動作を確認するテストコードを追加した
- stools_controllerにpメソッドが残っていたので、削除した