### PR TITLE
rspec:マイページの記録履歴一覧表示

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -47,15 +47,20 @@ class UsersController < ApplicationController
     # 連続記録日数のインスタンス変数
     @meal_log_days_record = 0
     @stool_log_days_record = 0
-    meal_date = Date.today
-    stool_date= Date.today
-    while current_user.eatings.where("DATE(created_at) = ?", meal_date).exists?
+    meal_start_day = Time.zone.now.beginning_of_day
+    meal_end_day = Time.zone.now.end_of_day
+    stool_start_day = Time.zone.now.beginning_of_day
+    stool_end_day = Time.zone.now.end_of_day
+
+    while current_user.eatings.where(created_at: meal_start_day..meal_end_day).exists?
       @meal_log_days_record += 1
-      meal_date = meal_date.prev_day
+      meal_start_day = meal_start_day - 1.day
+      meal_end_day = meal_end_day - 1.day
     end
-    while current_user.stools.where("DATE(created_at) = ?", stool_date).exists?
+    while current_user.stools.where(created_at: stool_start_day..stool_end_day).exists?
       @stool_log_days_record += 1
-      stool_date = stool_date.prev_day
+      stool_start_day = stool_start_day - 1.day
+      stool_end_day = stool_end_day - 1.day
     end
   end
 

--- a/app/views/shared/_log_index.html.erb
+++ b/app/views/shared/_log_index.html.erb
@@ -2,10 +2,10 @@
   <div class="card-body">
     <h2 class="card-title">記録履歴一覧</h2>
     <div class="flex">
-      <%= link_to '古い順', sort_log_users_path(asc: "true"), data: { turbo_method: :post, turbo_frame: "log_index_frame" }, class: "bg-base-300 hover:bg-base-200 font-bold py-2 px-4 rounded-full w-20" %>
-      <%= link_to '新しい順', sort_log_users_path(desc: "true"), data: { turbo_method: :post, turbo_frame: "log_index_frame" }, class: "bg-base-300 hover:bg-base-200 font-bold py-2 px-4 rounded-full w-24" %>
+      <%= link_to '古い順', sort_log_users_path(asc: "true"), data: { turbo_method: :post, turbo_frame: "log_index_frame" }, class: "bg-base-300 hover:bg-base-200 font-bold py-2 px-4 rounded-full w-20 asc-button" %>
+      <%= link_to '新しい順', sort_log_users_path(desc: "true"), data: { turbo_method: :post, turbo_frame: "log_index_frame" }, class: "bg-base-300 hover:bg-base-200 font-bold py-2 px-4 rounded-full w-24 desc-button" %>
     </div>
-    <div class="max-h-64 overflow-auto">
+    <div class="max-h-64 overflow-auto log-index">
       <table class="table table-xs table-pin-rows table-pin-cols">
         <thead>
           <tr>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -184,7 +184,7 @@
       <div class="card-body">
         <h2 class="card-title">セッティング</h2>
         <div>
-          <%= link_to (current_user.notifications_enabled ? "通知をオフにする" : "通知をオンにする"), toggle_notifications_path, data: { turbo_method: :post }, class: "bg-base-300 hover:bg-base-200 font-bold py-2 px-4 rounded-full w-20" %>
+          <%= link_to (current_user.notifications_enabled ? "通知をオフにする" : "通知をオンにする"), toggle_notifications_path, data: { turbo_method: :post }, class: "bg-base-300 hover:bg-base-200 font-bold py-2 px-4 rounded-full w-20 notifications-btn" %>
         </div>
         <div class="pt-4">
           <% unless current_user.id == 2 %>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     name { "Test User" }
     provider { "line" }
     uid { "123456" }
+    notifications_enabled { "false" }
   end
 end
 

--- a/spec/system/my_pages_spec.rb
+++ b/spec/system/my_pages_spec.rb
@@ -32,15 +32,25 @@ RSpec.describe "MyPages", type: :system do
       expect(meal_initial_number).to eq(0)
       expect(stool_initial_number).to eq(0)
 
-      # 食事記録を増やす
+      # 時刻設定
       current_time = Time.now.iso8601
+      one_month_ago = (DateTime.now << 1).iso8601
+      # 食事記録を増やす
       fill_in 'new_meal_name', with: 'Sample Meal'
       fill_in 'meal_created_at', with: current_time
+      find('.meal-btn').click
+
+      fill_in 'new_meal_name', with: 'Sample Meal'
+      fill_in 'meal_created_at', with: one_month_ago
       find('.meal-btn').click
 
       # 排便記録を増やす
       select '0.良い', from: 'condition'
       fill_in 'created_at', with: current_time
+      find('.stool-btn').click
+
+      select '0.良い', from: 'condition'
+      fill_in 'created_at', with: one_month_ago
       find('.stool-btn').click
 
       # 2つの表示部の数字が1増えていることを確認する
@@ -215,6 +225,56 @@ RSpec.describe "MyPages", type: :system do
         expect(find(:xpath, "//h3/strong[text()='便の状態ごとの記録回数(先月)']/following::p[2]").text).to eq('普通：1 回')
         expect(find(:xpath, "//h3/strong[text()='便の状態ごとの記録回数(先月)']/following::p[3]").text).to eq('悪い：1 回')
       end
+    end
+
+    it '記録履歴一覧cardの表示が正常であること' do
+      # @mealsが空の状態を確認する
+      within('.log-index') do
+        expect(page).to have_selector('table.table tbody tr', count: 0)
+      end
+
+      # 時刻設定
+      current_time = Time.now.iso8601
+      one_month_ago = (DateTime.now << 1).iso8601
+
+      # 現在時刻の食事記録を作成
+      fill_in 'new_meal_name', with: '今月のサンプル'
+      fill_in 'meal_created_at', with: current_time
+      find('.meal-btn').click
+
+      # 1月前の食事記録を作成
+      fill_in 'new_meal_name', with: '先月のサンプル'
+      fill_in 'meal_created_at', with: one_month_ago
+      find('.meal-btn').click
+
+      # 記録が追加されたことを確認する
+      within('.log-index') do
+        expect(page).to have_selector('table.table tbody tr', count: 2)
+        expect(find('table.table tbody tr td', text: '今月のサンプル')).to be_present
+        expect(find('table.table tbody tr td', text: '先月のサンプル')).to be_present
+      end
+
+      # 古い順の並び替えボタンを押す
+      
+      # 先月のサンプルが先に表示されていることを確認する
+  
+      # 保管した値の中身を確認する
+
+      # 新しい順の並び替えボタンを押す
+
+      # 今月のサンプルが先に表示されていることを確認する
+    end
+
+    it 'セッティングcardが正常に動作すること' do
+      # 通知変更ボタンをクリック
+
+      # テストユーザーのnotifications_enabledが変化していることを確認する
+
+      # 削除ボタンをクリック
+
+      # 確認ダイアログをクリック
+
+      # テストユーザーが消えていることを確認する
     end
   end
 end


### PR DESCRIPTION
# 概要
マイページの記録履歴一覧の動作テストを実装した。
capybaraでjsを有効化すること、それに関連するテストコードの実装は別途行う。

## 変更内容
- マイページの記録履歴一覧の動作テストを実装
- 連続記録日数の動作不良を修正