### PR TITLE
fix:定数をモデルファイルに移動&lin_bot_controllerにコメントを追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,38 +1,6 @@
 class ApplicationController < ActionController::Base
   skip_before_action :verify_authenticity_token
 
-  # 定数を定義する
-  # 記録済みテストユーザーid
-  RECORDED_TEST_USER_ID = 2
-
-  # 排便記録のenumの値確認用
-  STOOL_LOG_CONDITION_GOOD = 0
-  STOOL_LOG_CONDITION_NORMAL = 1
-  STOOL_LOG_CONDITION_BAD = 2
-
-  # 食事score変動用
-  MEAL_SCORE_CHANGE_ZERO = 0
-  MEAL_SCORE_CHANGE_PLUS = 1
-  MEAL_SCORE_CHANGE_MINUS = 2
-
-  # 排便の原因となる食事を特定する時間範囲
-  DETERMINING_COMPATIBILITY_START_TIME = 20
-  DETERMINING_COMPATIBILITY_END_TIME = 50
-
-  # おすすめの食事と避けるべき食事の判定基準の値
-  RECOMMEND_MEAL_JUDGE_FIRST_POINT = 3
-  RECOMMEND_MEAL_JUDGE_SECOND_POINT = 1
-  AVERT_MEAL_JUDGE_FIRST_POINT = -3
-  AVERT_MEAL_JUDGE_SECOND_POINT = -1
-
-  # 詳しい説明の最小と最大ページ番号
-  EXPLAIN_MIN_PAGE = 1
-  EXPLAIN_MAX_PAGE = 8
-
-  # 詳しい説明のページ移行用の値
-  PAGE_NUMBER_PLUS = 1
-  PAGE_NUMBER_MINUS = -1
-
   private
 
   # 記録履歴一覧用のインスタンス変数を作成、並び替え

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -23,4 +23,13 @@ class StaticPagesController < ApplicationController
       session[:number] = @number
     end
   end
+
+  # トップページで使用する定数の設定
+  # 詳しい説明の最小と最大ページ番号
+  EXPLAIN_MIN_PAGE = 1
+  EXPLAIN_MAX_PAGE = 8
+
+  # 詳しい説明のページ移行用の値
+  PAGE_NUMBER_PLUS = 1
+  PAGE_NUMBER_MINUS = -1
 end

--- a/app/controllers/stools_controller.rb
+++ b/app/controllers/stools_controller.rb
@@ -2,7 +2,7 @@ class StoolsController < ApplicationController
 
   def create
     if params[:condition] == ""
-      condition = STOOL_LOG_CONDITION_NORMAL
+      condition = Stool::STOOL_LOG_CONDITION_NORMAL
     else
       condition = params[:condition].to_i
     end
@@ -12,17 +12,17 @@ class StoolsController < ApplicationController
       render("user/show")
       return
     end
-    if condition == STOOL_LOG_CONDITION_GOOD
-      score_change = MEAL_SCORE_CHANGE_PLUS
-    elsif condition == STOOL_LOG_CONDITION_BAD
-      score_change = MEAL_SCORE_CHANGE_MINUS
+    if condition == Stool::STOOL_LOG_CONDITION_GOOD
+      score_change = Meal::MEAL_SCORE_CHANGE_PLUS
+    elsif condition == Stool::STOOL_LOG_CONDITION_BAD
+      score_change = Meal::MEAL_SCORE_CHANGE_MINUS
     else
       flash[:notice] = '排便を記録しました'
       redirect_to user_path(current_user)
       return
     end
-    start_time = stool.created_at - DETERMINING_COMPATIBILITY_START_TIME.hours
-    end_time = stool.created_at - DETERMINING_COMPATIBILITY_END_TIME.hours
+    start_time = stool.created_at - Eating::DETERMINING_COMPATIBILITY_START_TIME.hours
+    end_time = stool.created_at - Eating::DETERMINING_COMPATIBILITY_END_TIME.hours
     eatings = Eating.where(created_at: start_time..end_time).where(user_id: current_user.id)
     eatings.each do |eating|
       meal = Meal.find(eating.meal_id)
@@ -38,14 +38,14 @@ class StoolsController < ApplicationController
   def destroy
     stool = Stool.find(params[:id])
     if stool.condition == "good"
-      score_change = MEAL_SCORE_CHANGE_MINUS
+      score_change = Meal::MEAL_SCORE_CHANGE_MINUS
     elsif stool.condition == "bad"
-      score_change = MEAL_SCORE_CHANGE_PLUS
+      score_change = Meal::MEAL_SCORE_CHANGE_PLUS
     else
-      score_change = MEAL_SCORE_CHANGE_ZERO
+      score_change = Meal::MEAL_SCORE_CHANGE_ZERO
     end
-    start_time = stool.created_at - DETERMINING_COMPATIBILITY_START_TIME.hours
-    end_time = stool.created_at - DETERMINING_COMPATIBILITY_END_TIME.hours
+    start_time = stool.created_at - Eating::DETERMINING_COMPATIBILITY_START_TIME.hours
+    end_time = stool.created_at - Eatong::DETERMINING_COMPATIBILITY_END_TIME.hours
     eatings = Eating.where(created_at: start_time..end_time).where(user_id: current_user.id)
     eatings.each do |eating|
       meal = Meal.find(eating.meal_id)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,14 +3,14 @@ class UsersController < ApplicationController
 
   def show
     # おすすめの食事用のインスタンス変数
-    @recommend_meals = current_user.meals.where('score >= ?', RECOMMEND_MEAL_JUDGE_FIRST_POINT)
+    @recommend_meals = current_user.meals.where('score >= ?', Meal::RECOMMEND_MEAL_JUDGE_FIRST_POINT)
     if @recommend_meals.nil?
-      @recommend_meals = current_user.meals.where('score >= ?', RECOMMEND_MEAL_JUDGE_SECOND_POINT)
+      @recommend_meals = current_user.meals.where('score >= ?', Meal::RECOMMEND_MEAL_JUDGE_SECOND_POINT)
     end
     # 避けるべき食事用のインスタンス変数
-    @avert_meals = current_user.meals.where('score <= ?', AVERT_MEAL_JUDGE_FIRST_POINT)
+    @avert_meals = current_user.meals.where('score <= ?', Meal::AVERT_MEAL_JUDGE_FIRST_POINT)
     if @avert_meals.nil?
-      @avert_meals = current_user.meals.where('score >= ?', AVERT_MEAL_JUDGE_SECOND_POINT)
+      @avert_meals = current_user.meals.where('score >= ?', Meal::AVERT_MEAL_JUDGE_SECOND_POINT)
     end
 
     # 記録履歴一覧用のインスタンス変数
@@ -49,7 +49,7 @@ class UsersController < ApplicationController
     @stool_log_days_record = current_user.set_instance_stool_log_days
 
     # 記録済みテストユーザーのIDを格納する
-    @recorded_test_user_id = RECORDED_TEST_USER_ID
+    @recorded_test_user_id = User::RECORDED_TEST_USER_ID
   end
 
   def destroy

--- a/app/models/eating.rb
+++ b/app/models/eating.rb
@@ -4,4 +4,9 @@ class Eating < ApplicationRecord
 
   scope :this_month, -> { where(created_at: Time.current.beginning_of_month..Time.current.end_of_month) }
   scope :last_month, -> { where(created_at: Time.current.last_month.beginning_of_month..Time.current.last_month.end_of_month) }
+
+  # Eatingモデルに関連する定数の設定
+  # 排便の原因となる食事を特定する時間範囲
+  DETERMINING_COMPATIBILITY_START_TIME = 20
+  DETERMINING_COMPATIBILITY_END_TIME = 50
 end

--- a/app/models/meal.rb
+++ b/app/models/meal.rb
@@ -2,4 +2,16 @@ class Meal < ApplicationRecord
   belongs_to :user
   has_many :eatings, dependent: :destroy
   validates :meal_name, presence: true, length: { maximum: 30 }
+
+  # Mealモデルに関連する定数の設定
+  # 食事score変動用
+  MEAL_SCORE_CHANGE_ZERO = 0
+  MEAL_SCORE_CHANGE_PLUS = 1
+  MEAL_SCORE_CHANGE_MINUS = 2
+
+  # おすすめの食事と避けるべき食事の判定基準の値
+  RECOMMEND_MEAL_JUDGE_FIRST_POINT = 3
+  RECOMMEND_MEAL_JUDGE_SECOND_POINT = 1
+  AVERT_MEAL_JUDGE_FIRST_POINT = -3
+  AVERT_MEAL_JUDGE_SECOND_POINT = -1
 end

--- a/app/models/stool.rb
+++ b/app/models/stool.rb
@@ -6,4 +6,10 @@ class Stool < ApplicationRecord
   scope :this_month, -> { where(created_at: Time.current.beginning_of_month..Time.current.end_of_month) }
   scope :last_month, -> { where(created_at: Time.current.last_month.beginning_of_month..Time.current.last_month.end_of_month) }
   scope :condition_is, ->(condition) { where(condition: condition) }
+
+  # Stoolモデルに関連する定数の設定
+  # 排便記録のenumの値確認用
+  STOOL_LOG_CONDITION_GOOD = 0
+  STOOL_LOG_CONDITION_NORMAL = 1
+  STOOL_LOG_CONDITION_BAD = 2
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,4 +65,8 @@ class User < ApplicationRecord
 
     stool_log_days_record
   end
+
+  # Userモデルに関連する定数の設定
+  # 記録済みテストユーザーid
+  RECORDED_TEST_USER_ID = 2
 end


### PR DESCRIPTION
# 概要
コードの可読性を上げるための修正作業を行った。

## 変更内容
- application_controlelrに設定していた定数を、対応するモデルファイルに移動させた。
- line_bot_controllerの複雑化している記述に対して、コメント注釈を追加した。
- トップページの詳しい説明欄で使用する定数に関しては、対応するモデルが無いこと、該当箇所以外での使用用途がないことから、static_pages_controllerに配置した。