### PR TITLE
fix:linebotで排便記録した時の原因となる食事の記録時間を修正した

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -114,7 +114,7 @@ class LineBotController < ApplicationController
         break
       end
       # 食事名：記録日時という形式の文字列を作成して、変数に追加
-      stool_log_reply_message << "#{meal.meal_name}：#{meal.created_at.strftime("%-m-%d %H:%M")}\n"
+      stool_log_reply_message << "#{meal.meal_name}：#{eating.created_at.strftime("%-m-%d %H:%M")}\n"
     end
     message = {
                 type: "text",


### PR DESCRIPTION
# 概要
line botで排便記録をした際に、原因となった可能性のある食事名一覧を表示する機能がある。
表示された食事の記録時間がmealsテーブルから取得してしまっていたのを、eatingsテーブルのcreated_atを利用するように修正した。
これによって、正しい食事の記録時間がメッセージで表示されるようになった。