### PR TITLE
fix:オートコンプリートが動作しなくなっていたバグを修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,12 +18,14 @@ Rails.application.routes.draw do
 
   resource :user, only: %i[show destroy] do
     collection do
-      get :search
       post :sort, as: 'sort_log'
       post :toggle_notifications
       post :accept_terms
     end
   end
+  # stimulus_autocompleteの要求urlに合わせるために個別に設定
+  get 'users/search', to: 'users#search'
+
   resources :meals, only: %i[create]
   resources :stools, only: %i[create destroy]
   resources :eatings, only: %i[destroy]


### PR DESCRIPTION
# 概要
ルーティングファイルを整理した影響で、オートコンプリートの動作がバグっていたので修正

## 変更内容
- オートコンプリートの動作に必要なurl　users/searchのルーティングを個別に設定
- 修正前はresource :userのcollectionにネストさせていた。