### PR TITLE
fix:rakeタスク内のマジックナンバーを定数に格納した。

### DIFF
--- a/lib/tasks/log_notice.rake
+++ b/lib/tasks/log_notice.rake
@@ -1,6 +1,7 @@
 namespace :log_notice do
   desc "24時間記録が無いユーザーにlineメッセージを送信するタスク"
   task not_log_user_notice: :environment do
+    LAST_LOG_LIMIT_SECOND = 24 * 60 * 60
     current_time = Time.now
     users = User.all
     users.each do |user|
@@ -9,7 +10,7 @@ namespace :log_notice do
         last_stool = user.stools.order(created_at: :desc).limit(1).first
         if last_eating.nil? || last_stool.nil?
           break
-        elsif current_time - last_eating.created_at >= 24 * 60 * 60 || current_time - last_stool.created_at >= 24 * 60 * 60
+        elsif current_time - last_eating.created_at >= LAST_LOG_LIMIT_SECOND || current_time - last_stool.created_at >= LAST_LOG_LIMIT_SECOND
           message = {
               type: 'text',
               text: "前回の記録から24時間が経過しました。\n忘れてしまう前に食事と排便を記録しましょう。"


### PR DESCRIPTION
# 概要
一定時間記録していないユーザーに通知メッセージを送る機能のrakeタスクファイル内で、マジックナンバーを使用していたので、定数に格納した。