### PR TITLE
add:マイページのcardの説明吹き出しを表示するはてなアイコンの追加

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -85,7 +85,12 @@
           </div>
           <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
             <div class="card-body">
-              <h2 class="card-title">マイスコア</h2>
+              <div class="flex">
+                <h2 class="card-title mr-4">マイスコア</h2>
+                <div class="tooltip" data-tip="あなたがどれだけ記録を積み重ねたかを表すポイント">
+                  <button class="w-6 h-6 rounded-full border border-black">？</button>
+                </div>
+              </div>
               <div class="flex items-center justify-center text-9xl my-score">
                 <%= @log_count %>
               </div>
@@ -94,7 +99,12 @@
           </div>
           <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
             <div class="card-body">
-              <h2 class="card-title">連続記録日数</h2>
+              <div class="flex">
+                <h2 class="card-title mr-4">連続記録日数</h2>
+                <div class="tooltip" data-tip="今日の記録で何日連続で継続できているか">
+                  <button class="w-6 h-6 rounded-full border border-black">？</button>
+                </div>
+              </div>
               <h3><strong>食事の連続記録日数</strong></h3>
               <div class="flex items-center justify-center text-7xl meal-log-days-record">
                 <%= @meal_log_days_record %>
@@ -138,7 +148,12 @@
           </div>
           <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
             <div class="card-body">
-              <h2 class="card-title">おすすめの食事</h2>
+              <div class="flex">
+                <h2 class="card-title mr-4">おすすめの食事</h2>
+                <div class="tooltip" data-tip="良い状態の便の元となった可能性が高い食事">
+                  <button class="w-6 h-6 rounded-full border border-black">？</button>
+                </div>
+              </div>
               <div class="max-h-72 overflow-auto recommend-meal">
                 <% @recommend_meals.each do |recommend_meal| %>
                   <%= recommend_meal.meal_name %><br>
@@ -148,7 +163,12 @@
           </div>
           <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
             <div class="card-body">
-              <h2 class="card-title">避けるべき食事</h2>
+              <div class="flex">
+                <h2 class="card-title mr-4">避けるべき食事</h2>
+                <div class="tooltip" data-tip="悪い状態の便の元となった可能性が高い食事">
+                  <button class="w-6 h-6 rounded-full border border-black">？</button>
+                </div>
+              </div>
               <div class="max-h-72 overflow-auto avert-meal">
                 <% @avert_meals.each do |avert_meal| %>
                   <%= avert_meal.meal_name %><br>
@@ -158,7 +178,12 @@
           </div>
           <div class="card w-96 max-h-96 bg-base-100 shadow-xl mx-auto">
             <div class="card-body">
-              <h2 class="card-title">登録済みの食事名一覧</h2>
+              <div class="flex">
+                <h2 class="card-title mr-4">登録済みの食事名一覧</h2>
+                <div class="tooltip" data-tip="あなたが記録したことのある食事たち">
+                  <button class="w-6 h-6 rounded-full border border-black">？</button>
+                </div>
+              </div>
               <div class="max-h-72 overflow-auto meal-log-index">
                 <table class="table table-xs table-pin-rows table-pin-cols">
                   <thead>


### PR DESCRIPTION
# 概要
マイページのcard要素の中身を説明するはてなアイコンを追加

## 追加要素のイメージ
![スクリーンショット 2024-06-29 11 38 37](https://github.com/tkhero555/Puri.log/assets/145397763/2a1bba11-0db4-4785-80ad-8dc93790cf66)
